### PR TITLE
Disable Teku keystore locking

### DIFF
--- a/teku/entrypoint.sh
+++ b/teku/entrypoint.sh
@@ -15,4 +15,5 @@ exec /opt/teku/bin/teku --log-destination=CONSOLE \
   --validator-api-keystore-file=/cert/teku_client_keystore.p12 \
   --validator-api-keystore-password-file=/cert/teku_keystore_password.txt \
   --logging=ALL \
+  --validators-keystore-locking-enabled=false \ # To avoid teku restarting
   ${EXTRA_OPTS}

--- a/teku/entrypoint.sh
+++ b/teku/entrypoint.sh
@@ -15,5 +15,5 @@ exec /opt/teku/bin/teku --log-destination=CONSOLE \
   --validator-api-keystore-file=/cert/teku_client_keystore.p12 \
   --validator-api-keystore-password-file=/cert/teku_keystore_password.txt \
   --logging=ALL \
-  --validators-keystore-locking-enabled=false \ # To avoid teku restarting
+  --validators-keystore-locking-enabled=false \
   ${EXTRA_OPTS}


### PR DESCRIPTION
This issue is already known by Obol: https://docs.obol.tech/docs/int/faq/errors#teku-keystore-file-error

https://docs.teku.consensys.net/how-to/troubleshoot#keystore-file-already-in-use

https://docs.teku.consensys.net/reference/cli#validators-keystore-locking-enabled
